### PR TITLE
Add initial project README outlining Wellness Pomodoro VSC extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# hackathon2024
+# Wellness Pomodoro - A Developer Wellness Coach
+
+## About The Project
+
+Wellness Pomodoro is a Visual Studio Code extension designed to promote developer well-being by serving as an embedded wellness coach. Unlike traditional productivity tools that prioritize output, our focus is on sustaining developers' long-term health and career longevity through mindful work practices.
+
+### The Problem
+
+Software developers often struggle with:
+- Maintaining clear work-life boundaries
+- Taking regular breaks during intense coding sessions
+- Managing physical health while working long hours
+- Preventing burnout and mental fatigue
+- Sustaining eye health during screen time
+- Addressing sedentary work habits
+
+### Our Solution
+
+An intelligent VSCode extension that acts as a personal wellness coach, providing:
+- Context-aware break reminders
+- Wellness exercises and stretches
+- Eye strain prevention techniques
+- Mental health check-ins and encouragement
+- Long-term wellness tracking and progress visualization
+- Personalized recommendations based on working patterns
+
+## Features
+
+### Physical Wellness
+- Posture reminders
+- Stretching exercises
+- Movement prompts
+- Ergonomic guidance
+
+### Eye Health
+- 20-20-20 rule reminders (look at something 20 feet away for 20 seconds every 20 minutes)
+- Screen brightness adjustments
+- Eye exercise suggestions
+- Blue light exposure tracking
+
+### Mental Wellness
+- Mindfulness prompts
+- Stress-level check-ins
+- Break timing optimization
+- Positive reinforcement
+- Work pattern insights
+
+### Progress Tracking
+- Weekly wellness scorecards
+- Sprint-based health metrics
+- Monthly progress reports
+- Customizable goals and achievements
+
+## Technical Overview
+
+### Current Scope
+- Visual Studio Code extension
+- AI-powered coaching and personalization
+- Local data storage for progress tracking
+- Custom notification system
+
+### Future Considerations
+- Support for additional code editors
+- Enhanced AI capabilities
+- Cross-platform synchronization
+- Community features and shared wellness goals
+
+## Getting Started
+
+*Coming Soon*
+
+## Contributing
+
+We welcome contributions from the developer community! Whether it's adding new features, improving existing ones, or reporting bugs, your input helps make coding a healthier experience for everyone.
+
+## License
+
+*Coming Soon*
+
+## Project Status
+
+Currently in development. We are working on the initial implementation and welcome feedback on features that would best serve the developer community's wellness needs.
+
+## Why This Matters
+
+Traditional productivity tools often prioritize output over developer well-being. We believe that by focusing on the human experience of coding, we can help developers:
+- Build sustainable, long-term coding careers
+- Reduce burnout and fatigue
+- Improve physical and mental health
+- Maintain enthusiasm for their craft
+- Create better work-life balance
+
+Our goal is to transform how developers approach their daily work, making wellness an integral part of the coding experience rather than an afterthought.


### PR DESCRIPTION
This PR adds the initial README.md file for the Wellness Pomodoro project (or w/e we will call it)